### PR TITLE
Update price estimates as of 11 November 2025

### DIFF
--- a/_data/parts_list_case.yml
+++ b/_data/parts_list_case.yml
@@ -1,7 +1,7 @@
 - Description: Transportation case
   Component name: iM2975 Storm Travel Case with Foam
   Source: https://www.pelican.com/us/en/product/cases/travel-case/storm/im2975/
-  Unit price estimate ($): 400
+  Unit price estimate ($): 420
   Quantity: 1
   Assembly location: Case
   Vendor: Pelican

--- a/_data/parts_list_frame_box.yml
+++ b/_data/parts_list_frame_box.yml
@@ -2,7 +2,7 @@
   Component name: "1.00\u201D X 1.00\u201D T-Slotted Profile - Two Adjacent Open T-Slots (Part\
     \ No. 1002-S-Black-FB)"
   Source: https://8020.net/1002-s-black-fb.html
-  Unit price estimate ($): 38
+  Unit price estimate ($): 23
   Quantity: 2
   Assembly location: Box
   Vendor: 80/20
@@ -12,7 +12,7 @@
   Component name: "1.00\u201D X 1.00\u201D T-Slotted Profile - Two Adjacent Open T-Slots (Part\
     \ No. 1002-S-Black-FB)"
   Source: https://8020.net/1002-s-black-fb.html
-  Unit price estimate ($): 18
+  Unit price estimate ($): 12
   Quantity: 2
   Assembly location: Box
   Vendor: 80/20
@@ -22,7 +22,7 @@
   Component name: "1.00\u201D X 1.00\u201D T-Slotted Profile - Two Adjacent Open T-Slots (Part\
     \ No. 1002-S-Black-FB)"
   Source: https://8020.net/1002-s-black-fb.html
-  Unit price estimate ($): 23
+  Unit price estimate ($): 9
   Quantity: 4
   Assembly location: Box
   Vendor: 80/20
@@ -31,34 +31,34 @@
 - Description: Frame screws
   Component name: 1/4-20 x 1.000" Low Head Socket Cap Screw (LHSCS) (Part No. 3017)
   Source: https://8020.net/3017.html
-  Unit price estimate ($): 1
+  Unit price estimate ($): 21
   Quantity: 12
   Assembly location: Box
   Vendor: 80/20
-  Notes: These are 1/4-20 caps screws
+  Notes: Price estimate for pack of 25; these are 1/4-20 caps screws
 
 - Description: Corner brackets
   Component name: 10 Series 2 Hole - Gusseted Inside Corner Bracket (Part No. 4132-Black)
   Source: https://8020.net/4132-black.html
-  Unit price estimate ($): 8
+  Unit price estimate ($): 90
   Quantity: 4
   Assembly location: Box
   Vendor: 80/20
-  Notes:
+  Notes: Price estimate for pack of 10
 
 - Description: Corner connector
   Component name: 10 Series 3 Way - Squared Corner Connector (Part No. 4042-Black)
   Source: https://8020.net/4042-black.html
-  Unit price estimate ($): 34
+  Unit price estimate ($): 145
   Quantity: 4
   Assembly location: Box
   Vendor: 80/20
-  Notes:
+  Notes: Price estimate for pack of 4
 
 - Description: Acrylic sheets
   Component name: Clear Scratch- and UV-Resistant Cast Acrylic Sheets
-  Source: https://www.mcmaster.com/8560k192
-  Unit price estimate ($): 21
+  Source: https://www.mcmaster.com/product/8560K257
+  Unit price estimate ($): 22
   Quantity: 4
   Assembly location: Box
   Vendor: McMaster

--- a/_data/parts_list_frame_box.yml
+++ b/_data/parts_list_frame_box.yml
@@ -40,17 +40,17 @@
 - Description: Corner brackets
   Component name: 10 Series 2 Hole - Gusseted Inside Corner Bracket (Part No. 4132-Black)
   Source: https://8020.net/4132-black.html
-  Unit price estimate ($): 90
+  Unit price estimate ($): 9
   Quantity: 4
   Assembly location: Box
   Vendor: 80/20
-  Notes: Price estimate for pack of 10
+  Notes: Use custom quantity option
 
 - Description: Corner connector
   Component name: 10 Series 3 Way - Squared Corner Connector (Part No. 4042-Black)
   Source: https://8020.net/4042-black.html
   Unit price estimate ($): 145
-  Quantity: 4
+  Quantity: 1
   Assembly location: Box
   Vendor: 80/20
   Notes: Price estimate for pack of 4

--- a/_data/parts_list_optics.yml
+++ b/_data/parts_list_optics.yml
@@ -11,7 +11,7 @@
 - Description: Lyot stop iris
   Component name: "ID15 - Mounted Standard Iris, \xD815.0 mm Max Aperture, TR3 Post"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=ID15
-  Unit price estimate ($): 55
+  Unit price estimate ($): 63
   Quantity: 1
   Assembly location: LS
   Vendor: Thorlabs
@@ -29,7 +29,7 @@
 - Description: FPM translation stage
   Component name: DT12 - 1/2" Dovetail Translation Stage, 8-32 Taps
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=DT12
-  Unit price estimate ($): 85
+  Unit price estimate ($): 99
   Quantity: 1
   Assembly location: FPM
   Vendor: Thorlabs
@@ -38,7 +38,7 @@
 - Description: FPM protection cap
   Component name: SM1L10 - SM1 Lens Tube, 1.00" Thread Depth, One Retaining Ring Included
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=SM1L10
-  Unit price estimate ($): 15
+  Unit price estimate ($): 17
   Quantity: 1
   Assembly location: FPM
   Vendor: Thorlabs
@@ -47,7 +47,7 @@
 - Description: "1\u201D lens mount for FPM"
   Component name: "LMR1S - \xD81\" Lens Mount with Internal and External SM1 Threads, 8-32 Tap"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=LMR1S
-  Unit price estimate ($): 30
+  Unit price estimate ($): 34
   Quantity: 1
   Assembly location: FPM
   Vendor: Thorlabs
@@ -56,7 +56,7 @@
 - Description: Glasses for WFE
   Component name: "CG15XH1 - Precision Cover Glasses, #1.5H Thickness, \xD825 mm, Pack of 100"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CG15XH1
-  Unit price estimate ($): 65
+  Unit price estimate ($): 74
   Quantity: 1
   Assembly location: WFE
   Vendor: Thorlabs
@@ -65,7 +65,7 @@
 - Description: Broadband WFE option
   Component name: "WG10530 - \xD81/2\" N-BK7 Broadband Precision Window, Uncoated, t = 3 mm"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=WG10530
-  Unit price estimate ($): 60
+  Unit price estimate ($): 65
   Quantity: 1
   Assembly location: WFE
   Vendor: Thorlabs
@@ -74,7 +74,7 @@
 - Description: "0.5\u201D lens mount"
   Component name: "LMR05 - Lens Mount with Retaining Ring for \xD81/2\" Optics, 8-32 Tap"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=LMR05
-  Unit price estimate ($): 16
+  Unit price estimate ($): 19
   Quantity: 2
   Assembly location: Alignment, WFE
   Vendor: Thorlabs
@@ -83,7 +83,7 @@
 - Description: "1\u201D lens mount"
   Component name: "LMR1 - Lens Mount with Retaining Ring for \xD81\" Optics, 8-32 Tap"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=LMR1#ad-image-0
-  Unit price estimate ($): 16
+  Unit price estimate ($): 18
   Quantity: 3
   Assembly location: Aperture, Beam splitter, Laser
   Vendor: Thorlabs
@@ -92,7 +92,7 @@
 - Description: "1\u201Dx1\u201D magnetic mounts"
   Component name: 'KB1X1 - Complete 1" x 1" Kinematic Base, Top and Bottom Plates, #8 Counterbores'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=KB1X1
-  Unit price estimate ($): 80
+  Unit price estimate ($): 87
   Quantity: 3
   Assembly location: FPM, LS, WFE
   Vendor: Thorlabs
@@ -101,7 +101,7 @@
 - Description: Magnetic mount top plate
   Component name: 'KBT1X1 - Top Plate Only of the KB1X1 Kinematic Base, #8 Counterbore'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=KBT1X1
-  Unit price estimate ($): 40
+  Unit price estimate ($): 44
   Quantity: 1
   Assembly location: WFE
   Vendor: Thorlabs
@@ -110,7 +110,7 @@
 - Description: Magnetic mount bottom plates
   Component name: 'KBB1X1 - Bottom Plate Only of the KB1X1 Kinematic Base, #8 Counterbore'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=KBB1X1
-  Unit price estimate ($): 40
+  Unit price estimate ($): 44
   Quantity: 3
   Assembly location: Breadboard
   Vendor: Thorlabs
@@ -119,7 +119,7 @@
 - Description: Laser battery pack
   Component name: CPS1 - 5 VDC Battery Pack for CPS Laser Diodes, 10 000 mAh
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CPS1
-  Unit price estimate ($): 40
+  Unit price estimate ($): 45
   Quantity: 1
   Assembly location: Laser
   Vendor: Thorlabs
@@ -129,7 +129,7 @@
   Component name: "CPS532-C2 - Collimated Laser-Diode-Pumped DPSS Laser Module, 532 nm, 0.9\
     \ mW, Round Beam, \xD811 mm Housing"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CPS532-C2
-  Unit price estimate ($): 200
+  Unit price estimate ($): 203
   Quantity: 1
   Assembly location: Laser
   Vendor: Thorlabs
@@ -139,7 +139,7 @@
   Component name: "AD11F - SM1-Threaded Adapter for \xD811 mm, \u22650.35\" (8.9 mm) Long Cylindrical\
     \ Components\_"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=AD11F
-  Unit price estimate ($): 33
+  Unit price estimate ($): 37
   Quantity: 1
   Assembly location: Laser
   Vendor: Thorlabs
@@ -148,7 +148,7 @@
 - Description: Camera brackets
   Component name: AB90A - Right-Angle Bracket with Counterbored Slots & 1/4"-20 Tapped Holes
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=AB90A#ad-image-0
-  Unit price estimate ($): 30
+  Unit price estimate ($): 33
   Quantity: 2
   Assembly location: Cameras
   Vendor: Thorlabs
@@ -157,7 +157,7 @@
 - Description: "1\u201D post (grey)"
   Component name: "RS2P - \xD81\" Pedestal Pillar Post, 1/4\"-20 Taps, L = 2\""
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=RS2P
-  Unit price estimate ($): 30
+  Unit price estimate ($): 34
   Quantity: 2
   Assembly location: Cameras
   Vendor: Thorlabs
@@ -167,7 +167,7 @@
   Component name: "UPH2 - \xD81/2\" Universal Post Holder, Spring Loaded Locking Thumbscrew,\
     \ L = 2\" "
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=UPH2#ad-image-0
-  Unit price estimate ($): 35
+  Unit price estimate ($): 39
   Quantity: 10
   Assembly location: Aperture, Beam splitter, LS, Laser, Mirror 1, Mirror 2, Mirror 3,
     Alignment, WFE
@@ -177,7 +177,7 @@
 - Description: "0.5\u201D posts"
   Component name: "TR2 - \xD81/2\" Optical Post, SS, 8-32 Setscrew, 1/4\"-20 Tap, L = 2\u201D"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=TR2
-  Unit price estimate ($): 6
+  Unit price estimate ($): 7
   Quantity: 10
   Assembly location: Aperture, Beam splitter, LS, Laser, Mirror 1, Mirror 2, Mirror 3,
     Alignment, WFE
@@ -196,7 +196,7 @@
 - Description: Clamping forks
   Component name: CF125 - Clamping Fork, 1.24" Counterbored Slot, Universal
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CF125#ad-image-0
-  Unit price estimate ($): 9
+  Unit price estimate ($): 11
   Quantity: 2
   Assembly location: Cameras
   Vendor: Thorlabs
@@ -205,7 +205,7 @@
 - Description: Mirrors f=200mm
   Component name: "CM508-200-G01 - \xD82\" Aluminum-Coated Concave Mirror, f = 200.0 mm"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CM508-200-G01
-  Unit price estimate ($): 125
+  Unit price estimate ($): 138
   Quantity: 2
   Assembly location: Mirror 1, Mirror 2
   Vendor: Thorlabs
@@ -214,7 +214,7 @@
 - Description: Mirror f=150mm
   Component name: "CM508-150-G01 - \xD82\" Aluminum-Coated Concave Mirror, f = 150.0 mm"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CM508-150-G01
-  Unit price estimate ($): 125
+  Unit price estimate ($): 138
   Quantity: 1
   Assembly location: Mirror 3
   Vendor: Thorlabs
@@ -223,7 +223,7 @@
 - Description: Kinematic mirror mount
   Component name: "KM200 - Kinematic Mirror Mount for \xD82\" Optics"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=KM200#ad-image-0
-  Unit price estimate ($): 90
+  Unit price estimate ($): 97
   Quantity: 3
   Assembly location: Mirror 1, Mirror 2, Mirror 3
   Vendor: Thorlabs
@@ -232,7 +232,7 @@
 - Description: Beam splitter
   Component name: "EBP1 - Economy 30:70 Beamsplitter, \xD81\", AOI: 45\xB0"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=EBP1
-  Unit price estimate ($): 40
+  Unit price estimate ($): 41
   Quantity: 1
   Assembly location: Beam splitter
   Vendor: Thorlabs
@@ -241,7 +241,7 @@
 - Description: Breadboard
   Component name: MB1224 - Aluminum Breadboard 12" x 24" x 1/2", 1/4"-20 Taps
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=MB1224
-  Unit price estimate ($): 305
+  Unit price estimate ($): 324
   Quantity: 1
   Assembly location: Breadboard
   Vendor: Thorlabs
@@ -250,7 +250,7 @@
 - Description: Breadboard feet set
   Component name: BMF4 - Breadboard Mounting Feet (Imperial), Set of 4
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=BMF4
-  Unit price estimate ($): 30
+  Unit price estimate ($): 34
   Quantity: 1
   Assembly location: Breadboard
   Vendor: Thorlabs
@@ -259,7 +259,7 @@
 - Description: "0.5\u201D flat mirror"
   Component name: "PF05-03-P01 - \xD81/2\" Protected Silver Mirror\_"
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=PF05-03-P01
-  Unit price estimate ($): 33
+  Unit price estimate ($): 37
   Quantity: 1
   Assembly location: Alignment
   Vendor: Thorlabs
@@ -269,7 +269,7 @@
   Component name: 'MAP107575-A - 1:1 Matched Achromatic Pair, f1=75.0 mm, f2=75.0 mm, ARC: 400-700
     nm'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=MAP107575-A
-  Unit price estimate ($): 200
+  Unit price estimate ($): 223
   Quantity: 1
   Assembly location: Alignment
   Vendor: Thorlabs

--- a/_data/parts_list_optics.yml
+++ b/_data/parts_list_optics.yml
@@ -185,13 +185,13 @@
   Notes: One is for the flat alignment mirror
 
 - Description: Focal-plane and pupil-plane cameras
-  Component name: ZWO ASI120MC
-  Source:
-  Unit price estimate ($): 150
+  Component name: ZWO ASI662MC
+  Source: https://www.astroshop.eu/astronomical-cameras/zwo-camera-asi-662-mc-color/p,75719
+  Unit price estimate ($): 220
   Quantity: 2
   Assembly location: Cameras
   Vendor: ZWO
-  Notes: ZWO ASI 120 color cameras
+  Notes: ZWO ASI 662 color cameras
 
 - Description: Clamping forks
   Component name: CF125 - Clamping Fork, 1.24" Counterbored Slot, Universal

--- a/_data/parts_list_screw_kits.yml
+++ b/_data/parts_list_screw_kits.yml
@@ -1,7 +1,7 @@
 - Description: '1/4"-20 Cap Screw Kit'
   Component name: 'HW-KIT2 - 1/4"-20 Cap Screw and Hardware Kit'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=HW-KIT2
-  Unit price estimate ($): 135
+  Unit price estimate ($): 150
   Quantity: 1
   Vendor: Thorlabs
   Notes: 'Includes screws and washers'
@@ -9,7 +9,7 @@
 - Description: '8-32 Setscrew Kit'
   Component name: 'HW-KIT3 - 8-32 Setscrew and Hardware Kit'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=HW-KIT3
-  Unit price estimate ($): 130
+  Unit price estimate ($): 146
   Quantity: 1
   Vendor: Thorlabs
   Notes: 'Includes screws, washers and a hex key'

--- a/_data/parts_list_tools.yml
+++ b/_data/parts_list_tools.yml
@@ -1,7 +1,7 @@
 - Description: 'Key for 1/4"-20 cap screws (Balldriver)'
   Component name: 'BD-3/16 - 3/16" Balldriver'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=BD-3/16
-  Unit price estimate ($): 6
+  Unit price estimate ($): 7
   Assembly location: '1/4-20 cap screws'
   Vendor: Thorlabs
   Notes: IMPERIAL!!
@@ -9,7 +9,7 @@
 - Description: '0.5" spanner wrench'
   Component name: 'SPW603 - Spanner Wrench for SM05-Threaded Retaining Rings, Length = 1.00"'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=SPW603
-  Unit price estimate ($): 27
+  Unit price estimate ($): 31
   Assembly location: '0.5" lens mount'
   Vendor: Thorlabs
   Notes:
@@ -17,7 +17,7 @@
 - Description: '1" spanner wrench'
   Component name: 'SPW606 - Spanner Wrench for SM1-Threaded Retaining Rings, Length = 1.00"'
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=SPW606
-  Unit price estimate ($): 30
+  Unit price estimate ($): 34
   Assembly location: '1" lens mount, 1" lens mount for FPM'
   Vendor: Thorlabs
   Notes:
@@ -25,7 +25,7 @@
 - Description: 'Hex key set'
   Component name: CCHK - 11-Piece Color-Coded Hex Key Set, Imperial
   Source: https://www.thorlabs.com/thorproduct.cfm?partnumber=CCHK
-  Unit price estimate ($): 30
+  Unit price estimate ($): 31
   Assembly location: 'Laser mount/adapter, Kinematic mirror mount, 8-32 set screws'
   Vendor: Thorlabs
   Notes: IMPERIAL!!

--- a/_pages/parts-list.md
+++ b/_pages/parts-list.md
@@ -26,8 +26,8 @@ that allows you to take your baby coronagraph on adventures.
 ## Optical Components
 
 {: .notice--success}
-The total price estimate for the optical components listed below is **$4,200**.  
-Without the alignment tools and with the simpler aperture, this reduces to **$3,400**.
+The total price estimate for the optical components listed below is **$5,000**.  
+Without the alignment tools and with the simpler aperture, this reduces to **$3,800**.
 
 Note how the above price estimate includes the three alignment optics (labelled with "Alignment") which together cost
 ~$300 and can be omitted if you already own similar components.
@@ -192,7 +192,7 @@ sheets that can be assembled and disassembled. The frame box is designed to prot
 also during outreach and teaching activities.
 
 {: .notice--success}
-The total price estimate for the frame box is **$490**.
+The total price estimate for the frame box is **$430**.
 
 The frame box is extremely useful if you intend to transport your demo coronagraph in any sort of transportation case.
 

--- a/_pages/parts-list.md
+++ b/_pages/parts-list.md
@@ -34,7 +34,7 @@ Note how the above price estimate includes the three alignment optics (labelled 
 
 It is further possible to reduce the cost by replacing the laser-cut aperture mask listed in the table below with a
 2.5 mm [Thorlabs alignment tool](https://www.thorlabs.com/thorproduct.cfm?partnumber=AP2.5) that doubles as an aperture,
-for $12. The quality of the aperture image will be lower, but it is easy to upgrade this at a later time.
+for $13. The quality of the aperture image will be lower, but it is easy to upgrade this at a later time.
 
 [Download PDF](https://github.com/ivalaginja/babycat/tree/main/assets/pdfs/parts_list_optics.pdf){: .btn .btn--danger}
 


### PR DESCRIPTION
Updating the parts lists with new prices as of 11 November 2025, all rounded up to the nearest dollar.

Also updated the exact part for the acrylic sheets as they changed part numbers to a new sheet (same specs), and added a source for the ZWO cameras.