### PR TITLE
Fix deployment error

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
The error:

The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-buildYou can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml$ ruby-build 3.1.4 /opt/hostedtoolcache/Ruby/3.1.4/x64Once that completes successfully, mark it as complete with:$ touch /opt/hostedtoolcache/Ruby/3.1.4/x64.completeIt is your responsibility to ensure installing Ruby like that is not done in parallel.

From ChatGPT:

You don’t actually need to install Ruby yourself—the error is a red herring in this case.

What’s going on:

- GitHub recently moved ubuntu-latest to Ubuntu 24.04.
- The commit of ruby/setup-ruby you pinned (8575951…, v1.161.0) is too old and doesn’t recognise ubuntu-24.04 as a GitHub-hosted runner, so it assumes the runner is self-hosted and prints that scary message. 
- Newer versions of ruby/setup-ruby and/or using ubuntu-22.04 fix this.